### PR TITLE
Add filter reset and wishlist removal

### DIFF
--- a/src/components/ProductFilter.jsx
+++ b/src/components/ProductFilter.jsx
@@ -7,6 +7,12 @@ const ProductFilter = ({ setFilteredProducts }) => {
   const [category, setCategory] = useState("All");
   const [sortOrder, setSortOrder] = useState("asc");
 
+  const clearFilters = () => {
+    setSearch("");
+    setCategory("All");
+    setSortOrder("asc");
+  };
+
   // Cargar filtros guardados
   useEffect(() => {
     const savedFilters = JSON.parse(localStorage.getItem("filters"));
@@ -68,6 +74,10 @@ const ProductFilter = ({ setFilteredProducts }) => {
         <option value="asc">Precio: Menor a Mayor</option>
         <option value="desc">Precio: Mayor a Menor</option>
       </select>
+
+      <button type="button" onClick={clearFilters} className="filter-clear-button">
+        Limpiar Filtros
+      </button>
     </div>
   );
 };

--- a/src/pages/Wishlist.jsx
+++ b/src/pages/Wishlist.jsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import { toggleFavorite } from "../redux/wishlistSlice";
 import "../styles/Wishlist.css";
 
 const Wishlist = () => {
+  const dispatch = useDispatch();
   const favorites = useSelector((state) => state.wishlist.favorites);
 
   return (
@@ -18,6 +20,12 @@ const Wishlist = () => {
               <h3>{plant.name}</h3>
               <p>{plant.description}</p>
               <p className="wishlist-cost">{plant.cost}</p>
+              <button
+                className="wishlist-remove-button"
+                onClick={() => dispatch(toggleFavorite(plant))}
+              >
+                Eliminar
+              </button>
             </div>
           ))}
         </div>

--- a/src/styles/ProductFilter.css
+++ b/src/styles/ProductFilter.css
@@ -25,4 +25,17 @@
   .filter-input:focus, .filter-select:focus {
     border-color: #86A789;
   }
-  
+
+  .filter-clear-button {
+    background-color: #d9534f;
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.3s ease-in-out;
+  }
+
+  .filter-clear-button:hover {
+    background-color: #c9302c;
+  }

--- a/src/styles/Wishlist.css
+++ b/src/styles/Wishlist.css
@@ -30,4 +30,18 @@
     color: #4F6F52;
     font-weight: bold;
   }
-  
+
+  .wishlist-remove-button {
+    background-color: #d9534f;
+    color: white;
+    border: none;
+    padding: 6px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    margin-top: 8px;
+    transition: background 0.3s ease-in-out;
+  }
+
+  .wishlist-remove-button:hover {
+    background-color: #c9302c;
+  }


### PR DESCRIPTION
## Summary
- enable resetting product filters and add styles
- allow removing favorites from the wishlist
- clean stray prompt text from CSS files

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68423f27d3a0832eb53b575d7d3821e3