### PR TITLE
Fix install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ git clone https://github.com/fernandofarfan/tienda-de-plantas.git
 cd tienda-de-plantas
 npm install
 npm run dev
+```
+
+Abre tu navegador en `http://localhost:5173` para ver la aplicación.


### PR DESCRIPTION
## Summary
- close fenced block in README installation steps
- mention how to open the development server

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_684242eaa144832eb1b13ba91c459376